### PR TITLE
Add network functions - Fix renderless mode dt

### DIFF
--- a/network_client_example/client_sample_missile_custom_physics.py
+++ b/network_client_example/client_sample_missile_custom_physics.py
@@ -9,7 +9,7 @@ import time
 from math import sin, cos
 
 # Enter the IP and port displayed in top-left corner of DogFight screen
-df.connect("192.168.1.22", 50888)
+df.connect("192.168.42.86", 50888)
 
 time.sleep(2)
 
@@ -28,9 +28,16 @@ df.reset_machine(plane_id)
 # Get the plane missiles list
 missiles = df.get_machine_missiles_list(plane_id)
 
+
+
 # Get the missile id at slot 0
 missile_slot = 0
 missile_id = missiles[missile_slot]
+
+#Change missile settings
+df.set_missile_thrust_force(missile_id, 50)
+df.set_missile_angular_frictions(missile_id, 0.11,0.22,0.33)
+df.set_missile_drag_coefficients(missile_id, 1.1,2.2,3.2)
 
 # Set client update mode ON: the scene update must be done by client network, calling "update_scene()"
 df.set_client_update_mode(True)

--- a/network_client_example/dogfight_client.py
+++ b/network_client_example/dogfight_client.py
@@ -338,4 +338,13 @@ def get_missile_targets_list(missile_id):
 	state = json.loads((socket_lib.get_answer()).decode())
 	return state
 
+def set_missile_thrust_force(missile_id, thrust_force):
+	socket_lib.send_message(str.encode(json.dumps({"command": "SET_MISSILE_THRUST_FORCE", "args": {"missile_id": missile_id, "thrust_force": thrust_force}})))
+
+def set_missile_angular_frictions(missile_id, x, y, z):
+	socket_lib.send_message(str.encode(json.dumps({"command": "SET_MISSILE_ANGULAR_FRICTIONS", "args": {"missile_id": missile_id, "angular_frictions": [x, y, z]}})))
+
+def set_missile_drag_coefficients(missile_id, x, y, z):
+	socket_lib.send_message(str.encode(json.dumps({"command": "SET_MISSILE_DRAG_COEFFICIENTS", "args": {"missile_id": missile_id, "drag_coeff": [x, y, z]}})))
+
 

--- a/source/Machines.py
+++ b/source/Machines.py
@@ -1247,6 +1247,15 @@ class Missile(Destroyable_Machine):
             return ""
         else:
             return self.target.name
+    
+    def set_thrust_force(self, value:float):
+        self.f_thrust = value
+    
+    def set_angular_friction(self, x, y, z):
+        self.angular_frictions.x, self.angular_frictions.y, self.angular_frictions.z = x, y, z
+    
+    def set_drag_coefficients(self, x, y, z):
+        self.drag_coeff.x, self.drag_coeff.y, self.drag_coeff.z = x, y, z
 
 # =====================================================================================================
 #                                  Aircraft

--- a/source/master.py
+++ b/source/master.py
@@ -1481,7 +1481,10 @@ class Main:
                 Overlays.add_text2D("FPS %d" % (cls.num_fps), hg.Vec2(0.001, 0.999), 0.018, hg.Color.Yellow, cls.hud_font)
 
             # =========== State update:
-            used_dt = min(forced_dt * 2, real_dt)
+            if cls.flag_renderless:
+                used_dt = forced_dt
+            else:
+                used_dt = min(forced_dt * 2, real_dt)
             cls.current_state = cls.current_state(hg.time_to_sec_f(used_dt)) # Minimum frame rate security
             hg.SceneUpdateSystems(cls.scene, cls.clocks, used_dt, cls.scene_physics, used_dt, 1000)  # ,10,1000)
 
@@ -1502,7 +1505,7 @@ class Main:
 
             # =========== Renderless mode:
             else:
-                cls.update_renderless(real_dt)
+                cls.update_renderless(forced_dt)
 
             cls.clear_display_lists()
 

--- a/source/network_server.py
+++ b/source/network_server.py
@@ -107,6 +107,9 @@ def init_server(main_):
 		"SET_MISSILE_LIFE_DELAY": set_missile_life_delay,
 		"GET_MISSILE_TARGETS_LIST": get_missile_targets_list,
 		"SET_MISSILE_TARGET": set_missile_target,
+		"SET_MISSILE_THRUST_FORCE": set_missile_thrust_force,
+		"SET_MISSILE_ANGULAR_FRICTIONS": set_missile_angular_frictions,
+		"SET_MISSILE_DRAG_COEFFICIENTS": set_missile_drag_coefficients,
 
 		# Missile launchers
 		"GET_MISSILE_LAUNCHERS_LIST": get_missile_launchers_list,
@@ -936,7 +939,10 @@ def get_missile_state(args):
 		"linear_speed": machine.get_linear_speed(),
 		"target_id": machine.get_target_id(),
 		"life_delay": machine.life_delay,
-		"life_time": machine.life_cptr
+		"life_time": machine.life_cptr,
+		"thrust_force": machine.f_thrust,
+		"angular_frictions": [machine.angular_frictions.x, machine.angular_frictions.y, machine.angular_frictions.z],
+		"drag_coefficients": [machine.drag_coeff.x, machine.drag_coeff.y, machine.drag_coeff.z]
 		}
 	if flag_print_log:
 		print(args["missile_id"])
@@ -961,3 +967,15 @@ def get_missile_targets_list(args):
 	for t in targets:
 		targets_ids.append(t.name)
 	socket_lib.send_message(str.encode(json.dumps(targets_ids)))
+
+def set_missile_thrust_force(args):
+	missile = main.destroyables_items[args["missile_id"]]
+	missile.set_thrust_force(args["thrust_force"])
+
+def set_missile_angular_frictions(args):
+	missile = main.destroyables_items[args["missile_id"]]
+	missile.set_angular_friction(args["angular_frictions"][0], args["angular_frictions"][1], args["angular_frictions"][2] )
+
+def set_missile_drag_coefficients(args):
+	missile = main.destroyables_items[args["missile_id"]]
+	missile.set_drag_coefficients(args["drag_coeff"][0], args["drag_coeff"][1], args["drag_coeff"][2] )


### PR DESCRIPTION
Added functions to network mode:
-set_missile_thrust_force
-set_missile_angular_frictions
-set_missile_drag_coefficients

Fix the dt in Renderless mode: now you can set the dt with Main.timestep = float (in seconds)